### PR TITLE
Add install_requires for dependencies installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,14 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     python_requires='>=3.7.1',
+    install_requires=[
+        'colorama',
+        'tldextract',
+        'emojis',
+        'tldextract',
+        'pandas',
+        'matplotlib',
+    ],
     package_dir={'qualichat': 'qualichat'},
     package_data={
         'qualichat': ['books.txt'],


### PR DESCRIPTION
Address the proposed solution to Issue #1 by adding the `install_requires` parameter to `setup.py`, forcing dependencies installation.