### PR TITLE
feat: recover system events via _CapturingWhatsAppParser (stacked on #9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,14 +25,13 @@ parsed; everything else silently produced an empty chat.
   (string is still accepted for backwards compatibility).
 - **Version aligned**: `__version__` and `version_info` were out of sync
   (`1.4.3` vs `1.4.2`). Both are now `1.5.0`.
-
-### Breaking change
-
-- **`chat.system_messages` is always an empty list.** `chat-miner` discards
-  system events ("X joined", "media omitted", etc.) during parsing. Only the
-  `messages_per_actors_per_weekday` chart's "System Messages" option is
-  affected — it now plots zeros. A follow-up release will reintroduce system
-  events via a second pass.
+- **System events recovered.** Group lifecycle messages ("Bob added you",
+  "Jimbo left", "Loris created group X", end-to-end notice, …) are
+  reintroduced via a thin `WhatsAppParser` subclass that captures what the
+  upstream parser drops. They now populate `chat.system_messages` again, so
+  the `messages_per_actors_per_weekday` chart's "System Messages" option
+  works as before. Self-destroying messages (`Author:.`) remain skipped —
+  they carry no useful body.
 
 ### Removed
 

--- a/qualichat/chat.py
+++ b/qualichat/chat.py
@@ -18,13 +18,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+import datetime as _dt
 import tempfile
 import zipfile
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Union
+from typing import Any, Dict, Iterator, List, Tuple, Union
 
 from chatminer.chatparsers import WhatsAppParser
+from dateutil import parser as _datetimeparser  # transitive dep of chat-miner
 
 from .models import Actor, Message, SystemMessage
 from .utils import config, get_random_name, log
@@ -91,6 +93,54 @@ def _extract_txt_from_zip(zip_path: Path, dest: Path) -> Path:
         return dest / chosen
 
 
+class _CapturingWhatsAppParser(WhatsAppParser):
+    """``WhatsAppParser`` subclass that ALSO retains system events.
+
+    Upstream chat-miner returns ``None`` for any line that lacks an
+    ``Author: body`` separator — group lifecycle events ("Bob added you",
+    "Jimbo left", "Loris created group X"), media-omitted lines and so on
+    are dropped silently. We override :meth:`_parse_message` so that
+    whenever the upstream parser would skip a system event, we re-parse
+    just enough to recover ``(timestamp, body)`` and stash it in
+    ``self.system_events``.
+
+    Self-destroying messages (``Author:.``) remain skipped: they carry no
+    useful body.
+    """
+
+    def __init__(self, filepath: str) -> None:
+        super().__init__(filepath)
+        self.system_events: List[Tuple[_dt.datetime, str]] = []
+
+    def _parse_message(self, mess: str):  # type: ignore[override]
+        result = super()._parse_message(mess)
+        if result is not None:
+            return result
+
+        # super() returned None: either system event or self-destroying.
+        try:
+            datestr, author_and_body = mess.split(self._datefmt.date_author_sep, 1)
+        except ValueError:
+            return None
+
+        # Skip self-destroying ("X:.") and any line that does have a real
+        # author separator (defensive — super() should have already taken it).
+        if ': ' in author_and_body or ':.' in author_and_body:
+            return None
+
+        try:
+            time = _datetimeparser.parse(
+                datestr, dayfirst=self._datefmt.is_dayfirst, fuzzy=True,
+            )
+        except (ValueError, TypeError, OverflowError):
+            return None
+
+        body = author_and_body.strip()
+        if body:
+            self.system_events.append((time, body))
+        return None
+
+
 class Chat:
     """Represents a WhatsApp chat export.
 
@@ -113,8 +163,9 @@ class Chat:
     messages: List[:class:`.Message`]
         User messages, in chronological order.
     system_messages: List[:class:`.SystemMessage`]
-        Always empty in the current release — chat-miner discards system
-        events. See ``CHANGELOG.md`` for context.
+        Group lifecycle events (someone joined/left, group renamed,
+        end-to-end notice, etc.) recovered from the export. Self-destroying
+        messages are not included.
     """
 
     __slots__ = ('path', 'filename', 'messages', 'system_messages', '_actors')
@@ -132,10 +183,12 @@ class Chat:
         log_name = f'[green]{self.path}[/]'
         log('info', f'Loading chat {log_name}...')
 
-        df = self._parse(self.path)
+        df, system_events = self._parse(self.path)
 
         self.messages: List[Message] = []
-        self.system_messages: List[SystemMessage] = []
+        self.system_messages: List[SystemMessage] = [
+            SystemMessage(body, ts) for ts, body in system_events
+        ]
         self._actors: Dict[str, Actor] = {}
 
         path_key = str(self.path)
@@ -161,13 +214,18 @@ class Chat:
 
         log(
             'info',
-            f'Loaded {len(self.messages):,} messages and '
+            f'Loaded {len(self.messages):,} messages '
+            f'({len(self.system_messages):,} system events) and '
             f'{len(self._actors):,} actors from {log_name}.',
         )
 
     @staticmethod
     def _parse(path: Path):
-        """Run chat-miner against a (possibly zipped, possibly dirty) export."""
+        """Run chat-miner against a (possibly zipped, possibly dirty) export.
+
+        Returns a tuple ``(user_messages_df, system_events)`` where
+        ``system_events`` is a list of ``(timestamp, body)`` tuples.
+        """
         with ExitStack() as stack:
             if path.suffix.lower() == '.zip':
                 tmpdir = Path(stack.enter_context(
@@ -179,7 +237,7 @@ class Chat:
 
             cleaned = stack.enter_context(_cleaned_copy(source))
 
-            parser = WhatsAppParser(str(cleaned))
+            parser = _CapturingWhatsAppParser(str(cleaned))
             try:
                 parser.parse_file()
                 df = parser.parsed_messages.get_df(as_pandas=True)
@@ -192,6 +250,8 @@ class Chat:
                     "(Android or iOS, any supported locale)."
                 ) from exc
 
+            system_events = list(parser.system_events)
+
         if df.empty:
             raise ValueError(
                 f"No messages parsed from {path.name!r}. "
@@ -199,7 +259,7 @@ class Chat:
                 "(Android or iOS, any supported locale)."
             )
 
-        return df
+        return df, system_events
 
     @property
     def actors(self) -> List[Actor]:

--- a/scripts/validate_external.py
+++ b/scripts/validate_external.py
@@ -88,24 +88,25 @@ def main() -> int:
         try:
             chat = Chat(local)
             n_msgs = len(chat.messages)
+            n_sys = len(chat.system_messages)
             n_actors = len(chat.actors)
             status = "OK" if n_msgs > 0 else "EMPTY"
             if n_msgs == 0:
                 failures += 1
-            rows.append((status, n_msgs, n_actors, lic, label, ""))
+            rows.append((status, n_msgs, n_sys, n_actors, lic, label, ""))
         except Exception as exc:
-            rows.append(("FAIL", "-", "-", lic, label, f"{type(exc).__name__}: {exc}"))
+            rows.append(("FAIL", "-", "-", "-", lic, label, f"{type(exc).__name__}: {exc}"))
             failures += 1
 
     # silence the noisy chat-miner logging in the report block
     print()
-    print(f"{'STATUS':<8}{'#MSGS':>6}{'#ACTORS':>9}  {'LICENSE':<11}  FIXTURE")
-    print("-" * 100)
-    for status, n_msgs, n_actors, lic, label, err in rows:
-        print(f"{status:<8}{str(n_msgs):>6}{str(n_actors):>9}  {lic:<11}  {label}")
+    print(f"{'STATUS':<8}{'#MSGS':>6}{'#SYS':>6}{'#ACTORS':>9}  {'LICENSE':<11}  FIXTURE")
+    print("-" * 110)
+    for status, n_msgs, n_sys, n_actors, lic, label, err in rows:
+        print(f"{status:<8}{str(n_msgs):>6}{str(n_sys):>6}{str(n_actors):>9}  {lic:<11}  {label}")
         if err:
-            print(f"{'':<35}↳ {err}")
-    print("-" * 100)
+            print(f"{'':<41}↳ {err}")
+    print("-" * 110)
     print(f"Total: {len(SOURCES)} fixtures, {failures} failures")
 
     return 0 if failures == 0 else 1

--- a/tests/fixtures/with_system_events.txt
+++ b/tests/fixtures/with_system_events.txt
@@ -1,0 +1,12 @@
+[01/01/2021, 07:50:00] Bob created this group "Estudo"
+[01/01/2021, 07:50:01] Bob added Mary
+[01/01/2021, 07:50:02] Bob added Olivia
+[01/01/2021, 07:50:03] Bob added Joel
+[01/01/2021, 07:52:45] Joel: Olá pessoal!
+[01/01/2021, 07:52:47] Mary: Oi!
+[01/01/2021, 07:52:49] Joel: Como vão vocês?
+[01/01/2021, 07:52:55] Olivia: Tudo ótimo!
+[01/01/2021, 08:00:00] Mary left
+[01/01/2021, 08:00:30] Joel: Mary saiu, e agora?
+[01/01/2021, 08:01:00] Olivia changed the group description
+[01/01/2021, 08:05:00] Olivia: Bom, vamos seguir.

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -139,3 +139,34 @@ def test_message_features_computed():
     assert msg_with_link is not None
     assert "https://example.com/foo" in msg_with_link["Qty_char_links"]
     assert msg_with_link["Qty_char_total"] == len(msg_with_link.content)
+
+
+def test_system_events_captured():
+    """Group lifecycle events must populate `chat.system_messages`."""
+    import datetime as dt
+    from qualichat.chat import Chat
+
+    chat = Chat(FIXTURES / "with_system_events.txt")
+
+    # User messages: 5 lines with `Author: body`
+    assert len(chat.messages) >= 5
+
+    # System events: created, +3 added, left, changed description = 6
+    assert len(chat.system_messages) >= 5
+
+    bodies = [sm.content for sm in chat.system_messages]
+    assert any("created this group" in b for b in bodies)
+    assert any("added Mary" in b for b in bodies)
+    assert any("Mary left" in b for b in bodies)
+
+    # Each system message has a real datetime
+    assert all(isinstance(sm.created_at, dt.datetime) for sm in chat.system_messages)
+
+
+def test_system_events_empty_when_no_events():
+    """A chat without lifecycle events keeps `chat.system_messages` empty."""
+    from qualichat.chat import Chat
+
+    chat = Chat(FIXTURES / "ios_new_pt.txt")
+    assert isinstance(chat.system_messages, list)
+    assert len(chat.system_messages) == 0


### PR DESCRIPTION
## Stacked on top of #9

This PR is **based on** \`feat/parser-chatminer\` (PR #9), not \`main\`. It must be merged AFTER #9 — or rebased onto \`main\` after #9 lands.

## Why

PR #9 documented as a breaking change that \`chat.system_messages\` would always be empty, because chat-miner drops group lifecycle events at parse time. This restores them so we ship a clean v1.5.0 with no behavioural regression vs v1.4.x.

## What

\`WhatsAppParser._parse_message\` returns \`None\` for any line lacking an \`Author: body\` separator. We subclass it and override \`_parse_message\` to re-parse just enough to recover \`(timestamp, body)\` for the lines that \`super()\` decided to drop, while still ignoring self-destroying messages (\`Author:.\`).

```python
class _CapturingWhatsAppParser(WhatsAppParser):
    def _parse_message(self, mess):
        result = super()._parse_message(mess)
        if result is not None:
            return result
        # super() dropped it — try to recover as system event
        ...
        self.system_events.append((time, body))
```

- \`Chat._parse\` now returns \`(df, system_events)\`
- \`Chat.__init__\` builds \`SystemMessage\` objects from the captured events
- New fixture \`tests/fixtures/with_system_events.txt\`: created group / +3 added / left / description-changed mixed with user messages
- 2 new tests: events captured, absent-fixture stays \`[]\`
- CHANGELOG drops the v1.5.0 "breaking change" callout and folds the recovery into "Changes"
- \`scripts/validate_external.py\` also reports \`#SYS\` now

## Test plan

Local: **16/16 unit tests pass**, **7/7 external fixtures still pass** with system events now populated:

\`\`\`
STATUS   #MSGS  #SYS  #ACTORS  LICENSE      FIXTURE
--------------------------------------------------------------------------------------------------------------
OK           6     2        5  MIT          chat-miner: ddmmyy 24h
OK           6     2        5  MIT          chat-miner: mmddyy 24h (US)
OK           6     2        5  MIT          chat-miner: mmddyyyy 12h (Spanish AM/PM)
OK           6     2        5  MIT          chat-miner: yyyymmdd 24h (ISO)
OK           6     2        5  MIT          chat-miner: brackets mmddyy 24h
OK          38     4        5  no-license   toneworm: iOS recent EN with LRM
OK          48     4        3  MIT          Pustur: example.zip (Android DE)
\`\`\`

- [x] \`pytest tests -v\` 16/16 on Python 3.10.0 (Windows)
- [ ] CI on Python 3.10 + 3.11 (Linux)
- [ ] Round-trip: \`messages_per_actors_per_weekday\` "System Messages" option plots non-zero counts again