### PR TITLE
fix: three frames.py bugs (lru_cache on generator, typo branch, model mismatch)

### DIFF
--- a/qualichat/__main__.py
+++ b/qualichat/__main__.py
@@ -113,7 +113,9 @@ def setup(parser: ArgumentParser, args: Namespace) -> None:
 
     with progress_bar(transient=True) as progress:
         progress.add_task('[green]Downloading spaCy models[/]', start=False)
-        download('pt_core_news_md', False, False, '-q')
+        # Must match the model name spacy.load() uses in qualichat.frames
+        # (`_spacy_pt` calls `spacy.load('pt_core_news_sm')`).
+        download('pt_core_news_sm', False, False, '-q')
         download('en_core_web_sm', False, False, '-q')
 
     print('\n[green]✔ You can now use Qualichat.[/green]')

--- a/qualichat/frames.py
+++ b/qualichat/frames.py
@@ -81,18 +81,32 @@ def _normalize_row(row: List[int], actor: str, chat: Chat) -> List[int]:
     return [int(i / len(chat.actors)) for i in row]
 
 
+@lru_cache(maxsize=1)
+def _spacy_pt():
+    return spacy.load('pt_core_news_sm')
+
+
 @lru_cache(maxsize=1000)
-def _parse_nlp(word: str, *, pos: str):
-    nlp = spacy.load('pt_core_news_sm')
+def _parse_nlp(word: str, *, pos: str) -> Tuple[str, ...]:
+    """Tokenise ``word`` with the PT spaCy model and return tokens of POS ``pos``.
+
+    Returns a ``tuple`` (not a generator) so the ``lru_cache`` actually caches
+    the values — caching a generator object yields an exhausted iterator on
+    every subsequent hit.
+    """
+    nlp = _spacy_pt()
     doc = nlp(word)
     endings = ('ar', 'er', 'ir')
 
+    tokens: List[str] = []
     for token in doc:
-        if token.pos_ == pos:
-            if pos == 'VERB' and not token.text.endswith(endings):
-                continue
+        if token.pos_ != pos:
+            continue
+        if pos == 'VERB' and not token.text.endswith(endings):
+            continue
+        tokens.append(token.text)
 
-            yield token.text
+    return tuple(tokens)
 
 
 def _parse_nlp_messages(messages: List[Message]):
@@ -664,7 +678,7 @@ class ParticipationStatusFrame(BaseFrame):
         msg = 'Choose you action'
         result = select(msg, choices).ask()
 
-        if result == 'Machinations per Actors':
+        if result == 'Fabrications per Actors':
             return _fabrications_per_actors(chats, title)
         else:
             return _average_fabrications(chats, title)


### PR DESCRIPTION
## Three independent bug fixes

This PR is **independent of #9 and #10** — it only touches \`frames.py\` and \`__main__.py\`. It can land before or after the parser overhaul; rebases cleanly either way. No version bump (let the maintainer pick at release time).

### 1. \`@lru_cache\` on a generator function (silent data loss)

[\`frames.py:84\`](https://github.com/qualichat/qualichat/blob/main/qualichat/frames.py#L84) had:

\`\`\`python
@lru_cache(maxsize=1000)
def _parse_nlp(word: str, *, pos: str):
    nlp = spacy.load('pt_core_news_sm')
    ...
    yield token.text
\`\`\`

\`@lru_cache\` caches the **generator object**, not its yielded values. The first call iterates and returns words; the second call gets the same generator object back — already exhausted — and returns nothing. Result: every word is processed once across the cache's lifetime, but every cache hit silently produces an empty result, corrupting whichever wordcloud / chart consumed the cached path second.

**Fix:** return a \`tuple\` (eager evaluation, hashable, cache-friendly). Also lift \`spacy.load(...)\` into a separate \`_spacy_pt()\` cached helper so the pt_core_news_sm model is loaded once per process instead of being reloaded for every unique \`(word, pos)\` entry into the cache.

### 2. Typo \`'Machinations per Actors'\` (dead branch)

[\`frames.py:667\`](https://github.com/qualichat/qualichat/blob/main/qualichat/frames.py#L667):

\`\`\`python
choices = ['Fabrications per Actors', 'Average Fabrications']
result = select(msg, choices).ask()

if result == 'Machinations per Actors':   # ← typo, never matches
    return _fabrications_per_actors(chats, title)
else:
    return _average_fabrications(chats, title)
\`\`\`

The user-visible label is "Fabrications per Actors", but the dispatch compares against "Machinations". The first branch is unreachable, so picking "Fabrications per Actors" silently falls through to \`_average_fabrications()\`. Whole \`_fabrications_per_actors()\` function is unreachable from the menu.

**Fix:** s/Machinations/Fabrications/.

### 3. Setup downloads the wrong spaCy model

[\`__main__.py:116\`](https://github.com/qualichat/qualichat/blob/main/qualichat/__main__.py#L116):

\`\`\`python
download('pt_core_news_md', False, False, '-q')   # downloaded
\`\`\`

But [\`frames.py:86\`](https://github.com/qualichat/qualichat/blob/main/qualichat/frames.py#L86):

\`\`\`python
nlp = spacy.load('pt_core_news_sm')                # required at runtime
\`\`\`

After running \`python -m qualichat setup\`, \`pt_core_news_md\` is installed but \`_sm\` is not — every chart that touches \`_parse_nlp\` blows up with \`OSError: Can't find model 'pt_core_news_sm'\`.

**Fix:** align setup to download \`pt_core_news_sm\` (matching the runtime call). \`_sm\` is also lighter (~12MB vs ~40MB) and we don't use any \`_md\`-only feature.

## Test plan

- [ ] Visual: pick "Fabrications per Actors" in the CLI → \`_fabrications_per_actors()\` runs (was unreachable before)
- [ ] Manual: run \`KeysFrame.keyword\` on a chat twice with the same keyword → second wordcloud is non-empty (was empty before due to exhausted generator)
- [ ] Fresh \`python -m qualichat setup\` then \`python -m qualichat load chat.txt\` and pick a chart that hits \`_parse_nlp\` → no \`OSError\` for missing \`pt_core_news_sm\`

No automated tests added — these all exercise the \`questionary\` REPL or require the spaCy PT model in CI, both heavy. Reviewable by inspection.