### PR TITLE
docs: rewrite api.rst to match the actual frame classes

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -47,29 +47,52 @@ Chat Analyzers
 
 
 Frames
---------
+------
 
-.. autofunction:: qualichat.frames.generate_chart
+A *Frame* groups together a set of charts that can be rendered for the loaded
+chats. Three frames ship with Qualichat:
+
+- :class:`~qualichat.frames.KeysFrame` — keyword and lexical-feature charts
+  (laminations, links, calls, e-mails, textual symbols, video ratings).
+- :class:`~qualichat.frames.ParticipationStatusFrame` — per-actor activity,
+  message statistics, media repertoire, fabrications/laminations, bot
+  detection.
+- :class:`~qualichat.frames.PublicOpinionFrame` — sentiment matrix and
+  thematic linkage based on the bundled ``connector.csv`` vocabulary.
 
 .. autoclass:: qualichat.frames.BaseFrame
     :members:
 
-.. autoclass:: qualichat.frames.MessagesFrame
+.. autoclass:: qualichat.frames.KeysFrame
     :members:
 
-.. autoclass:: qualichat.frames.ActorsFrame
+.. autoclass:: qualichat.frames.ParticipationStatusFrame
     :members:
 
-.. autoclass:: qualichat.frames.TimeFrame
+.. autoclass:: qualichat.frames.PublicOpinionFrame
     :members:
 
-.. autoclass:: qualichat.frames.NounsFrame
-    :members:
 
-.. autoclass:: qualichat.frames.VerbsFrame
-    :members:
+Sorters & Chart Generators
+--------------------------
 
-.. autoclass:: qualichat.frames.EmojisFrame
+The :mod:`qualichat.sorters` module hosts decorators that drive the sorting
+choices presented in the interactive CLI, plus the low-level chart, table,
+treemap and wordcloud renderers built on top of Plotly.
+
+.. autofunction:: qualichat.sorters.keys
+
+.. autofunction:: qualichat.sorters.participation_status
+
+.. autofunction:: qualichat.sorters.group_users
+
+.. autofunction:: qualichat.sorters.generate_chart
+
+.. autofunction:: qualichat.sorters.generate_table
+
+.. autofunction:: qualichat.sorters.generate_treemap
+
+.. autofunction:: qualichat.sorters.generate_wordcloud
 
 
 Abstract Base Classes
@@ -185,7 +208,7 @@ format.
 Models
 ------
 
-Models are classes created by the library to represent an element of the chat. 
+Models are classes created by the library to represent an element of the chat.
 They are not intended to be instantiated by the user of the library.
 
 .. warning::
@@ -204,7 +227,7 @@ Actors
 
 Messages
 ~~~~~~~~
-    
+
 .. autoclass:: qualichat.models.Message()
     :members:
     :inherited-members:


### PR DESCRIPTION
## Why

The Sphinx ``docs/api.rst`` was written for the original (pre-v1.3) frame layout and was never updated when the codebase rewrote them. RTD builds currently emit Sphinx warnings on every \`autoclass\` directive that points at a class that does not exist.

Six frame classes were referenced but never existed in current code:

- \`qualichat.frames.MessagesFrame\` ❌
- \`qualichat.frames.ActorsFrame\` ❌
- \`qualichat.frames.TimeFrame\` ❌
- \`qualichat.frames.NounsFrame\` ❌
- \`qualichat.frames.VerbsFrame\` ❌
- \`qualichat.frames.EmojisFrame\` ❌

The three frames that **actually** ship are:

- \`qualichat.frames.KeysFrame\` ✅
- \`qualichat.frames.ParticipationStatusFrame\` ✅
- \`qualichat.frames.PublicOpinionFrame\` ✅

Also \`qualichat.frames.generate_chart\` was referenced — that helper was moved to \`qualichat.sorters\` in the v1.3 rewrite.

## What

- Replace the dead \`autoclass\` directives with the real frame classes.
- Add a short blurb explaining what a Frame is.
- Replace the broken \`qualichat.frames.generate_chart\` reference with a new "Sorters & Chart Generators" section that points at the actual public symbols in \`qualichat.sorters\`:
  - \`generate_chart\`, \`generate_table\`, \`generate_treemap\`, \`generate_wordcloud\`
  - the \`keys\`, \`participation_status\`, \`group_users\` decorators

No code change. No version bump. This is a docs-only PR, independent of #9 / #10 / #11; it merges cleanly onto \`main\` regardless of order.

## Out of scope

The actual docstrings on \`KeysFrame\`, \`ParticipationStatusFrame\`, etc. are still empty (\`""""""\`) in the codebase. Filling them out is a larger separate effort — this PR only fixes references so the existing build stops emitting warnings on missing classes.

## Test plan

- [ ] Local \`sphinx-build -W docs docs/_build\` succeeds (no warnings about missing classes for these references). Other warnings in the repo (e.g. missing \`SystemMessage\` docstrings) pre-date this PR.
- [ ] RTD build at https://qualichat.readthedocs.io renders the API page with KeysFrame / ParticipationStatusFrame / PublicOpinionFrame after merge.