### PR TITLE
feat: multi-locale message types + anonymisation/setup cleanups (stacked on #10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ parsed; everything else silently produced an empty chat.
   the `messages_per_actors_per_weekday` chart's "System Messages" option
   works as before. Self-destroying messages (`Author:.`) remain skipped —
   they carry no useful body.
+- **`MessageType` detection is now multi-locale.** `enums.get_message_type`
+  used to recognise eight hard-coded pt-BR strings; all other locales fell
+  back to `MessageType.default`, so non-pt-BR exports flagged every media
+  line as a regular text message and skewed every chart that filtered on
+  type. Now recognises pt-BR, en, es, de, it and fr tokens (case-insensitive,
+  whitespace-tolerant) plus the Android `<Media omitted>` / `<Mídia oculta>`
+  generic. iOS document lines are still detected by suffix match.
+- **`get_random_name()` no longer raises `IndexError`** when the bundled
+  `books.txt` pool of 767 names is exhausted. Falls back to sequential
+  `Actor #N` placeholders so chats with > 767 distinct actors load cleanly.
+- **`setup.py` author typo fixed**: `Erneist Manhein` → `Ernest Manheim`
+  (matches `__author__` in `qualichat/__init__.py`).
 
 ### Removed
 

--- a/qualichat/enums.py
+++ b/qualichat/enums.py
@@ -20,6 +20,7 @@ SOFTWARE.
 
 import datetime
 from enum import Enum, IntEnum
+from typing import Dict, Tuple
 
 
 __all__ = ('Period', 'SubPeriod', 'MessageType')
@@ -105,24 +106,117 @@ def get_sub_period(created_at: datetime.datetime) -> SubPeriod:
     return sub_period
 
 
-def get_message_type(content: str) -> MessageType:
-    if content == 'imagem ocultada':
-        message_type = MessageType.image_omitted
-    elif content == 'GIF omitido':
-        message_type = MessageType.gif_omitted
-    elif content == 'vídeo omitido':
-        message_type = MessageType.video_omitted
-    elif content == 'áudio ocultado':
-        message_type = MessageType.audio_omitted
-    elif content == 'figurinha omitida':
-        message_type = MessageType.sticker_omitted
-    elif content.endswith('documento omitido'):
-        message_type = MessageType.document_omitted
-    elif content == 'Cartão do contato omitido':
-        message_type = MessageType.contact_card_omitted
-    elif content == 'Mensagem apagada':
-        message_type = MessageType.deleted_message
-    else:
-        message_type = MessageType.default
+# Per-MessageType detection tokens.
+#
+# The exact strings WhatsApp emits depend on platform (iOS / Android) and
+# locale. These tables cover the most common locales we have evidence for in
+# real exports: pt-BR, en, es, de, it, fr. Add to the relevant tuple if you
+# encounter a new locale — please prefer the literal string the app emits
+# (case-insensitive comparison is applied by ``get_message_type``).
+#
+# Note: most tokens are matched exactly against the trimmed message body;
+# document tokens are also matched as a *suffix* because iOS prefixes them
+# with the filename (e.g. ``"report.pdf • 2 pages documento omitido"``).
+# The Android generic ``<media omitted>`` / ``<Mídia oculta>`` lines are
+# treated as ``image_omitted`` for back-compat with previous releases.
+_OMITTED_TOKENS: Dict[MessageType, Tuple[str, ...]] = {
+    MessageType.image_omitted: (
+        'imagem ocultada', 'imagem oculta',           # pt-BR
+        'image omitted',                               # en
+        'imagen omitida',                              # es
+        'Bild weggelassen',                            # de
+        'immagine omessa',                             # it
+        'image omise',                                 # fr
+        '<Media omitted>',                             # Android (en, generic)
+        '<Mídia oculta>',                              # Android (pt-BR)
+    ),
+    MessageType.gif_omitted: (
+        'GIF omitido',                                 # pt-BR
+        'GIF omitted',                                 # en
+        'GIF omitida', 'GIF omitida.',                 # es
+        'GIF ausgeschlossen',                          # de
+        'GIF omessa',                                  # it
+        'GIF omise',                                   # fr
+    ),
+    MessageType.video_omitted: (
+        'vídeo omitido',                               # pt-BR
+        'video omitted',                               # en
+        'video omitido',                               # es
+        'Video weggelassen',                           # de
+        'video omesso',                                # it
+        'vidéo omise',                                 # fr
+    ),
+    MessageType.audio_omitted: (
+        'áudio ocultado', 'áudio oculto',              # pt-BR
+        'audio omitted',                               # en
+        'audio omitido',                               # es
+        'Audio weggelassen',                           # de
+        'audio omesso',                                # it
+        'audio omis',                                  # fr
+    ),
+    MessageType.sticker_omitted: (
+        'figurinha omitida',                           # pt-BR
+        'sticker omitted',                             # en
+        'pegatina omitida', 'sticker omitido',         # es
+        'Sticker weggelassen',                         # de
+        'adesivo omesso',                              # it
+        'autocollant omis',                            # fr
+    ),
+    MessageType.document_omitted: (
+        'documento omitido',                           # pt-BR / es / it
+        'document omitted',                            # en
+        'Dokument weggelassen',                        # de
+        'document omis',                               # fr
+    ),
+    MessageType.contact_card_omitted: (
+        'Cartão do contato omitido',                   # pt-BR
+        'Contact card omitted',                        # en
+        'Tarjeta de contacto omitida',                 # es
+        'Kontaktkarte weggelassen',                    # de
+        'biglietto da visita omesso',                  # it
+        'Carte de contact omise',                      # fr
+    ),
+    MessageType.deleted_message: (
+        'Mensagem apagada',                            # pt-BR
+        'This message was deleted',                    # en
+        'Mensaje eliminado',                           # es
+        'Diese Nachricht wurde gelöscht',              # de
+        'Questo messaggio è stato eliminato',          # it
+        'Ce message a été supprimé',                   # fr
+    ),
+}
 
-    return message_type
+# Build a lower-cased lookup once at import time so detection is cheap.
+_OMITTED_LOOKUP: Dict[str, MessageType] = {
+    token.casefold(): msg_type
+    for msg_type, tokens in _OMITTED_TOKENS.items()
+    for token in tokens
+}
+
+
+def get_message_type(content: str) -> MessageType:
+    """Classify a message body as a media/system token or as a regular message.
+
+    Recognises platform-/locale-specific strings WhatsApp uses for omitted
+    media, deleted messages and the like. Falls back to
+    :attr:`MessageType.default` for anything else (i.e. real text content).
+
+    Detection is case-insensitive and tolerates leading/trailing whitespace.
+    Document tokens additionally match as a *suffix* because iOS prefixes
+    them with the filename.
+    """
+    if not content:
+        return MessageType.default
+
+    normalized = content.strip().casefold()
+
+    # Exact-match against the lookup table (covers most cases).
+    if (msg_type := _OMITTED_LOOKUP.get(normalized)) is not None:
+        return msg_type
+
+    # iOS document lines are "<filename> ... documento omitido" → suffix match.
+    for token in _OMITTED_TOKENS[MessageType.document_omitted]:
+        if normalized.endswith(token.casefold()):
+            return MessageType.document_omitted
+
+    return MessageType.default

--- a/qualichat/utils.py
+++ b/qualichat/utils.py
@@ -89,9 +89,23 @@ def _get_all_names() -> List[str]:
         return f.read().split('\n')
 
 
+_exhaustion_counter = 0
+
+
 def get_random_name() -> str:
+    """Pick a unique anonymising display name for an actor.
+
+    Names are drawn (and removed) from the bundled ``books.txt`` pool. If the
+    pool is exhausted — chats with > 767 distinct actors — fall back to
+    sequential ``"Actor #N"`` placeholders so we never raise ``IndexError``
+    mid-load. Uniqueness is preserved.
+    """
+    global _exhaustion_counter
+    if not names:
+        _exhaustion_counter += 1
+        return f'Actor #{_exhaustion_counter}'
     name = random.choice(names)
-    # Remove the book from the list so there is no risk that two 
+    # Remove the book from the list so there is no risk that two
     # actors have the same display name.
     names.remove(name)
     return name.strip()

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ class CheckVisualStudioCommand(Command):
 
 setup(
     name='qualichat',
-    author='Erneist Manhein',
+    author='Ernest Manheim',
     project_urls={
         'Documentation': 'https://qualichat.readthedocs.io/en/latest/',
         'Issue tracker': 'https://github.com/qualichat/qualichat/issues',

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,0 +1,80 @@
+"""Tests for qualichat.enums.get_message_type — multi-locale detection."""
+
+import pytest
+
+from qualichat.enums import MessageType, get_message_type
+
+
+@pytest.mark.parametrize(
+    "content,expected",
+    [
+        # pt-BR (iOS)
+        ("imagem ocultada",            MessageType.image_omitted),
+        ("imagem oculta",              MessageType.image_omitted),
+        ("GIF omitido",                MessageType.gif_omitted),
+        ("vídeo omitido",              MessageType.video_omitted),
+        ("áudio ocultado",             MessageType.audio_omitted),
+        ("áudio oculto",               MessageType.audio_omitted),
+        ("figurinha omitida",          MessageType.sticker_omitted),
+        ("Cartão do contato omitido",  MessageType.contact_card_omitted),
+        ("Mensagem apagada",           MessageType.deleted_message),
+        # Android (en, generic)
+        ("<Media omitted>",            MessageType.image_omitted),
+        # Android (pt-BR)
+        ("<Mídia oculta>",             MessageType.image_omitted),
+        # en
+        ("image omitted",              MessageType.image_omitted),
+        ("video omitted",              MessageType.video_omitted),
+        ("audio omitted",              MessageType.audio_omitted),
+        ("sticker omitted",            MessageType.sticker_omitted),
+        ("Contact card omitted",       MessageType.contact_card_omitted),
+        ("This message was deleted",   MessageType.deleted_message),
+        # es
+        ("imagen omitida",             MessageType.image_omitted),
+        ("Mensaje eliminado",          MessageType.deleted_message),
+        # de
+        ("Bild weggelassen",           MessageType.image_omitted),
+        ("Diese Nachricht wurde gelöscht", MessageType.deleted_message),
+        # it
+        ("immagine omessa",            MessageType.image_omitted),
+        # fr
+        ("image omise",                MessageType.image_omitted),
+        ("Ce message a été supprimé",  MessageType.deleted_message),
+    ],
+)
+def test_get_message_type_locales(content, expected):
+    assert get_message_type(content) == expected
+
+
+def test_get_message_type_case_insensitive():
+    """Detection must be case-insensitive (real exports vary capitalisation)."""
+    assert get_message_type("IMAGE OMITTED") == MessageType.image_omitted
+    assert get_message_type("Image Omitted") == MessageType.image_omitted
+    assert get_message_type("imagem OCULTADA") == MessageType.image_omitted
+
+
+def test_get_message_type_whitespace_tolerance():
+    """Leading/trailing whitespace must not block detection."""
+    assert get_message_type("  imagem ocultada  ") == MessageType.image_omitted
+    assert get_message_type("\timage omitted\n") == MessageType.image_omitted
+
+
+def test_get_message_type_document_suffix():
+    """iOS document lines look like '<filename> ... documento omitido'."""
+    assert get_message_type("relatorio.pdf • 2 pages documento omitido") == \
+        MessageType.document_omitted
+    assert get_message_type("contract.pdf document omitted") == \
+        MessageType.document_omitted
+
+
+def test_get_message_type_default_for_text():
+    """Plain text messages should fall back to default (no false positives)."""
+    assert get_message_type("Olá pessoal!") == MessageType.default
+    assert get_message_type("Hello everyone!") == MessageType.default
+    assert get_message_type("") == MessageType.default
+    # Edge case: word "image" inside a sentence should NOT be flagged
+    assert get_message_type("I love this image of the sunset") == MessageType.default
+
+
+def test_get_message_type_empty_string():
+    assert get_message_type("") == MessageType.default

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,48 @@
+"""Tests for qualichat.utils — anonymisation pool exhaustion."""
+
+import pytest
+
+
+def test_get_random_name_returns_from_pool():
+    """When the pool has names, get_random_name returns and consumes one."""
+    from qualichat import utils
+
+    initial_size = len(utils.names)
+    assert initial_size > 0
+
+    name = utils.get_random_name()
+    assert isinstance(name, str)
+    assert name  # not empty
+    assert len(utils.names) == initial_size - 1
+
+
+def test_get_random_name_does_not_raise_when_pool_exhausted():
+    """A chat with more actors than `books.txt` lines must not crash mid-load."""
+    from qualichat import utils
+
+    # Force exhaustion
+    utils.names.clear()
+    utils._exhaustion_counter = 0
+
+    a = utils.get_random_name()
+    b = utils.get_random_name()
+    c = utils.get_random_name()
+
+    assert a == "Actor #1"
+    assert b == "Actor #2"
+    assert c == "Actor #3"
+
+    # All three must be unique
+    assert len({a, b, c}) == 3
+
+
+def test_get_random_name_unique_within_pool():
+    """While the pool has names, every call must return a different name."""
+    from qualichat import utils
+
+    seen = set()
+    n = min(50, len(utils.names))
+    for _ in range(n):
+        name = utils.get_random_name()
+        assert name not in seen, f"Duplicate display name returned: {name!r}"
+        seen.add(name)


### PR DESCRIPTION
## Stacked on #10 (and therefore on #9)

Base: \`feat/system-messages\` → \`feat/parser-chatminer\` → \`main\`. This PR depends on the test infrastructure introduced in #9; merging it before #9/#10 land would fail CI.

## Three independent hardening items, bundled because each is small

### 1. \`get_message_type\` is now multi-locale (the meaty one)

[\`qualichat/enums.py\`](https://github.com/qualichat/qualichat/blob/main/qualichat/enums.py#L108) hard-coded eight pt-BR strings (\`"imagem ocultada"\`, \`"GIF omitido"\`, …). Every export in **en, es, de, it, fr** — plus Android's generic \`<Media omitted>\` and pt-BR's \`<Mídia oculta>\` — classified each media line as \`MessageType.default\`. Result: every chart that filters by \`Type\` silently lost media events on non-pt-BR exports (\`KeysFrame.*\` via \`MessageType.default\` guards, \`ParticipationStatusFrame\` bot heuristics that count \`video_omitted\` / \`sticker_omitted\`, …).

Replaced the chain of \`==\` checks with a per-locale token table built once at import time:

\`\`\`python
_OMITTED_TOKENS: Dict[MessageType, Tuple[str, ...]] = {
    MessageType.image_omitted: (
        'imagem ocultada', 'imagem oculta',           # pt-BR
        'image omitted',                               # en
        'imagen omitida',                              # es
        'Bild weggelassen',                            # de
        'immagine omessa',                             # it
        'image omise',                                 # fr
        '<Media omitted>',                             # Android (en, generic)
        '<Mídia oculta>',                              # Android (pt-BR)
    ),
    ...
}
_OMITTED_LOOKUP = { token.casefold(): t  for t, ts in _OMITTED_TOKENS.items() for token in ts }
\`\`\`

Detection is now case-insensitive, whitespace-tolerant, and the iOS document suffix match (\`"filename.pdf … documento omitido"\`) is preserved.

### 2. Anonymisation pool exhaustion no longer raises

[\`qualichat/utils.py:92\`](https://github.com/qualichat/qualichat/blob/main/qualichat/utils.py#L92) called \`random.choice(names)\` directly and raised \`IndexError\` on the 768th distinct actor (the bundled \`books.txt\` has 767 names). Real WhatsApp groups can exceed that.

Added a guard that falls back to sequential \`"Actor #N"\` placeholders. Uniqueness is preserved (each call increments a module-level counter). The fallback only triggers once the pool empties, so existing behaviour is untouched for chats with ≤ 767 actors.

### 3. \`setup.py\` author typo

\`author='Erneist Manhein'\` → \`'Ernest Manheim'\` to match \`__author__\` in \`qualichat/__init__.py\`.

## Test plan

\`pytest tests -v\` → **48 / 48 passing** locally on Python 3.10.0 (Windows).

Composition:
- 16 from \`test_chat.py\` (carried from #9 + #10)
- 27 from new \`test_enums.py\`: each locale × MessageType, case-insensitivity, whitespace, document suffix, no-false-positive-on-real-text
- 3 from new \`test_utils.py\`: pool consumption, exhaustion fallback returns unique \`Actor #N\`, in-pool uniqueness

CI matrix (3.10 + 3.11) will run on push.

## Out of scope (still)

- Locales we have no real-export evidence for (Arabic, Russian, Japanese, …). Easy to extend the table when a sample lands.
- Self-destroying ("view once") messages — chat-miner drops them and they have no useful body to recover.