### PR TITLE
docs: add methodology, divergences, AUTHORS and CITATION

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,81 @@
+# Authors and Acknowledgements
+
+Qualichat is the product of an academic research project incubated at
+UNICAMP between 2020 and 2022, with international collaboration and
+funding. The authors below are recognised in the way they describe
+their own contributions in the project's public materials.
+
+## Academic team
+
+- **Fernando Luiz Nobre Cavalcante** — *creator, principal investigator*
+  (also published as **Kochav Koren Nobre**). PhD in Media Studies,
+  UFRN (2019); MA in Sociology, UFC (2015). Postdoctoral researcher at
+  UNICAMP IEL (2020–2022). Founder of the Ernest Manheim Public
+  Opinion Laboratory. Now Adjunct Professor of Communication &
+  Rhetorical Studies, Duquesne University, Pittsburgh.
+  - LinkedIn: [kochavkoren](https://www.linkedin.com/in/kochavkoren/)
+  - Medium: [nobrecavalcante](https://nobrecavalcante.medium.com/)
+- **Marcelo El Khouri Buzato** — *postdoctoral supervisor*. Full
+  Professor of Applied Linguistics, UNICAMP IEL. Co-founder of the
+  Centre for Research in Post-Humanism and Digital Humanities (PH2D),
+  coordinator of the LiTPos research group.
+- **Michael Manfred Hanke** — *co-author of the foundational paper*
+  (Cavalcante & Hanke, 2020). Habilitation in Communication Sciences
+  (Essen, 1998); PhD in Linguistic Studies (Essen, 1991). Professor of
+  the Graduate Programme in Media Studies, UFRN.
+- **Centre for Media, Communication and Information Research (ZeKMI),
+  University of Bremen** — *international partner*, hosted Cavalcante
+  as visiting researcher 2020–2022.
+
+## Software contributors
+
+- **kyomi** ([bitterteriyaki](https://github.com/bitterteriyaki)) —
+  *principal developer* of the Python implementation. ~95% of the
+  commits. Currently a Computer Science undergraduate at UnB
+  (Universidade de Brasília); previously an intern at the Ernest
+  Manheim Public Opinion Laboratory.
+- **Caio Alexandre** — *developer*, contributing to earlier iterations
+  of the code.
+- **Cazé / Moisés** ([cazemoises](https://github.com/cazemoises)) —
+  *maintainer* of the 2023–2024 fix cycle (PRs #5, #7, #8).
+- **Vitor Mussa** — *author of [qualichat-qualitube](https://github.com/qualichat/qualichat-qualitube)*,
+  the YouTube Data API integration developed in collaboration with the
+  Federal University of Bahia (UFBA).
+- **João Paulo** — *Computer Science partner* at the Ernest Manheim
+  Public Opinion Laboratory.
+
+## Design
+
+- **Pedro Oliver** (Brasília) — *logo design*. The Qualichat mark is
+  styled after a peacock — *"o pavão misterioso"* — as Cavalcante
+  recounts in the 2022 *Escola de Dados* webinar.
+
+## Funding and institutional support
+
+- **American Political Science Association (APSA)** — Cavalcante
+  received the *Fund for Latino Scholarship* (2020).
+- **UNICAMP — Instituto de Estudos da Linguagem (IEL)** — host
+  institution of the postdoctoral fellowship.
+- **University of Bremen — ZeKMI** — international partner.
+- **Ernest Manheim Public Opinion Laboratory** (São Paulo, founded
+  2012, CNPJ 17.022.589/0001-21) — Cavalcante's research and
+  consultancy lab; provided continuity infrastructure.
+
+## Honoured namesake
+
+The tool, the supporting laboratory and the `__author__` field of the
+Python package all honour **Ernest Manheim** (1900–2002), the
+Hungarian-American sociologist whose 1933 habilitation thesis *Die
+Träger der öffentlichen Meinung* ("The Makers of Public Opinion")
+pioneered the theory of public opinion as a *social tie* rather than a
+poll aggregate. The project's thinking on framing-as-vincular-tie
+descends directly from his work via Goffman's frame analysis.
+
+## How to be added
+
+If you have contributed code, documentation, fixtures, translations or
+peer feedback and are not listed, please open a pull request that adds
+your name in the appropriate section. The project follows the spirit
+of the
+[All Contributors](https://allcontributors.org/) specification — every
+form of contribution is recognised.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,59 @@
+# https://citation-file-format.github.io/
+cff-version: 1.2.0
+message: >-
+  If you use Qualichat in academic work, please cite *both* the software
+  (this entry) and the foundational paper that describes its methodology
+  (the `preferred-citation` block below).
+
+title: Qualichat
+abstract: >-
+  Open-source linguistic ethnography tool for framing public opinion in
+  mediatised groups. Operationalises the quanti-qualitative methodology
+  proposed by Cavalcante & Hanke (2020) for the analysis of WhatsApp
+  group exports, with anchorage-aware metrics, anonymisation and
+  Goffman-derived frame analysis.
+
+type: software
+license: MIT
+url: "https://github.com/qualichat/qualichat"
+repository-code: "https://github.com/qualichat/qualichat"
+keywords:
+  - whatsapp
+  - linguistic-ethnography
+  - frame-analysis
+  - public-opinion
+  - digital-humanities
+  - quanti-qualitative
+  - python
+
+authors:
+  - family-names: Nobre Cavalcante
+    given-names: Fernando Luiz
+    alias: Kochav Koren Nobre
+    affiliation: Duquesne University
+
+  - family-names: Buzato
+    given-names: Marcelo El Khouri
+    affiliation: Universidade Estadual de Campinas (UNICAMP)
+
+  - family-names: Hanke
+    given-names: Michael Manfred
+    affiliation: Universidade Federal do Rio Grande do Norte (UFRN)
+
+preferred-citation:
+  type: article
+  title: "Ancoragens de interação em grupos midiatizados: proposta quantiqualitativa"
+  authors:
+    - family-names: Nobre Cavalcante
+      given-names: Fernando Luiz
+    - family-names: Hanke
+      given-names: Michael Manfred
+  journal: Comunicação Mídia e Consumo
+  volume: 17
+  issue: "50"
+  year: 2020
+  start: 536
+  end: 558
+  doi: 10.18568/cmc.v17i49.2227
+  url: "https://revistacmc.espm.br/revistacmc/article/view/2227"
+  issn: "1983-7070"

--- a/docs/divergences.rst
+++ b/docs/divergences.rst
@@ -1,0 +1,217 @@
+Divergences between specification and implementation
+====================================================
+
+This page documents where the current code departs from the analytical
+specification published in 2021, with a frank assessment of severity
+and the maintainers' standing decision for each item.
+
+The point of the page is **not** to call out bugs. The current
+behaviour has been in production since approximately v1.3 and is
+familiar to existing users; correcting any individual divergence would
+be a behaviour change that affects ongoing research workflows. The
+maintainers' default is therefore *preserve current behaviour, document
+the gap*. Each item below records that decision so it can be revisited
+deliberately by a future maintainer (or by the project's creator) when
+appropriate.
+
+For the analytical foundation against which these are compared, see
+:doc:`methodology`.
+
+
+Source of truth
+---------------
+
+The specification is the **Keys frame flowchart** included as the
+opening figure of *Como instalar o Qualichat* (Medium, 2021), and
+republished as a one-page document on Academia.edu under the title
+*Qualichat Menu-Keys Framing Flowchart* (2021). The flowchart is the
+only published map of the menu hierarchy and its expected outputs.
+
+No equivalent published flowcharts have been located for the
+*Participation Status* or *Public Opinion* frames. The divergences
+listed below are therefore restricted to the *Keys* frame; the other
+two frames cannot be audited the same way without consulting the
+project's creator or recovering the missing diagrams.
+
+
+Summary table
+-------------
+
+============== =========================================== ==================== ===============================
+Severity       Item                                        Code reference       Decision
+============== =========================================== ==================== ===============================
+🔴 Critical    `laminations` chart shows components,       ``frames.py:227-265`` Keep current behaviour
+               not the net-character residue
+🔴 Critical    `messages` chart only renders a wordcloud,  ``frames.py:204-225`` Keep current behaviour
+               not the character-count panels
+🔴 Critical    `keyword` chart produces a single wordcloud ``frames.py:174-201`` Keep current behaviour
+               for the chosen morphological class, not                          (Open issue for review)
+               the three simultaneous wordclouds the
+               flowchart specifies
+🟡 Medium      Sorting modes: only "By Time" / "By Actor"  ``sorters.py:362-378`` Keep current behaviour
+               are offered; the flowchart's "By Group"
+               mode is absent
+🟡 Cosmetic    The flowchart's terminal label "Gráfico de  multiple              No action needed
+               Relevância" is not used in the UI
+🟢 Addition    `ratings` chart exists in code but not in   ``frames.py:395-480`` Keep — added 2022 with
+               the 2021 flowchart                                                ``qualichat-qualitube``
+============== =========================================== ==================== ===============================
+
+
+Detailed analysis
+-----------------
+
+D1 — `laminations` chart shows the components, not the residue
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Specification.** The flowchart specifies that the *Laminações* node
+yields *Quantidade líquida de caracteres* — the net-character residue
+that remains after the laminating elements are subtracted. The formula
+is stated explicitly:
+
+.. code-block:: text
+
+    Qtd._liq._car. = Qtd._car._msg.
+                     − ( Qtd._car._chamadas
+                       + Qtd._car._links
+                       + Qtd._car._emails
+                       + Qtd._car._emojis/símbolos )
+
+**Current implementation** (``KeysFrame.laminations``,
+``frames.py:227-265``). The chart plots **the laminations themselves**
+as four bar series — links, e-mails, calls, emojis — with the message
+count overlaid as a line. The net-character figure is computed
+upstream (``Qty_char_net`` in :py:mod:`qualichat.models`) but never
+appears in this chart's output.
+
+**Severity: critical (semantic).** The chart produces information that
+is *related* to the spec (showing the components instead of the
+residue is the same conceptual surface viewed from the inverse
+direction), but a researcher reading the chart and following the
+flowchart's promise would be expecting a different number on the
+y-axis. The discrepancy is masked because the chart's title says
+"*Laminations*", which is technically what is plotted.
+
+**Decision.** Preserve current behaviour. Restoring the spec would
+mean changing what *every existing user* of this chart sees — and
+several drill-down charts (``links``, ``calls``, ``emails``) re-use the
+component pattern, so consistency matters.
+
+A future PR could add a *new* chart called ``net_text`` (or rename
+the current ``laminations`` to ``laminating_components`` and add
+``laminations_net``) without breaking existing flows.
+
+
+D2 — `messages` chart skips the character-count panels
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Specification.** The flowchart's *Mensagens* node has four downstream
+outputs:
+
+1. *Total de caracteres da mensagem* (total character count)
+2. *Total de caracteres da mensagem por lexical* (character count per
+   morphological class)
+3. *Quantidade de verbos* / *substantivos* / *adjetivos* (word counts
+   per morphological class)
+4. (Implicit) the wordcloud is treated as a fourth, separate output.
+
+**Current implementation** (``KeysFrame.messages``, ``frames.py:204-225``).
+The chart prompts for a single morphological class and produces a
+single wordcloud for it. Outputs 1, 2 and 3 from the spec are absent.
+
+**Severity: critical (analytical).** The four spec outputs together
+let a researcher compare *which class carries the message* — does
+this group's discourse anchor in nouns (referents) or verbs (action)
+or adjectives (judgement)? The wordcloud alone does not surface that
+contrast.
+
+**Decision.** Preserve current behaviour. Adding the three count
+panels is a chart redesign, not a bug fix; it changes the rendering
+flow significantly.
+
+
+D3 — `keyword` chart yields one wordcloud, not three
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Specification.** The flowchart's *Pal.-chave* sub-flow shows three
+parallel wordclouds — *Nuv. pal. de verbos por palavra-chave*, *Nuv.
+pal. de substantivos por palavra-chave*, *Nuv. pal. de adjetivos por
+palavra-chave* — produced **simultaneously**, not as user-selectable
+alternatives.
+
+**Current implementation** (``KeysFrame.keyword``, ``frames.py:174-201``).
+The chart prompts the user to pick **one** morphological class, then
+generates a single wordcloud filtered to that class.
+
+**Severity: critical (analytical).** The same logic as D2: comparing
+the three classes side by side is the analytical move; offering them
+as a one-of-three choice forces the researcher to do three runs and
+hold the comparison in memory, which is fragile.
+
+**Decision.** Preserve current behaviour. This is the most defensible
+*candidate for a future fix*, because:
+
+- The change is a UX rearrangement (run the inner loop three times
+  and emit three wordclouds) without changing any data or formula.
+- The performance cost is bounded (3× tokenisation per chat).
+- It restores fidelity to the spec without any architectural impact.
+
+A maintenance PR that adds an opt-in ``All classes`` option to the
+existing prompt would deliver the spec behaviour without breaking the
+existing ``one class at a time`` workflow.
+
+
+D4 — Missing "By Group" sorting mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Specification.** The flowchart's bottom panel shows three
+*Preparação por quadros* modes — *Quadros por tempo*, *Quadros por
+ator*, *Quadros por grupo* — each with its own *Seleção específica*
+prompt feeding into the final relevance chart.
+
+**Current implementation** (``sorters.keys`` decorator,
+``sorters.py:362-378``). Only two modes are offered: ``By Time`` and
+``By Actor``.
+
+**Severity: medium.** *Quadros por grupo* would only matter when
+multiple chats are loaded — and even then, the existing dropdown on
+the rendered Plotly figure (``All Chats / chat_a / chat_b``) provides
+inter-chat navigation post-hoc.
+
+**Decision.** Preserve current behaviour. The existing dropdown
+covers the practical need; adding a third sorting branch would
+require a new sorter helper (``_sort_by_group``) without obvious
+analytical gain.
+
+
+D5 — `ratings` chart exists in code but not in the flowchart
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Specification.** The 2021 flowchart contains no *Ratings* node.
+
+**Current implementation** (``KeysFrame.ratings``, ``frames.py:395-480``).
+The chart fetches YouTube view / like / comment counts for every
+shared YouTube link in the chat, using
+:py:mod:`qualichat-qualitube` (an add-on by Vitor Mussa, UFBA).
+
+**Severity: addition (not a regression).** Cavalcante mentions the
+qualitube integration explicitly in the 2022 webinar as a *new*
+collaboration with UFBA, post-dating the 2021 flowchart. The chart is
+therefore a deliberate extension, not an undocumented drift.
+
+**Decision.** No action needed. Ensure the methodology page records
+this as an addition (it does — see :doc:`methodology`).
+
+
+Items still to be audited
+-------------------------
+
+The following audits are pending because the corresponding published
+specifications have not been located:
+
+- The complete flowchart for the *Participation Status* frame.
+- The complete flowchart for the *Public Opinion* frame.
+- The exact list of expected outputs for each chart in those frames.
+
+Anyone with access to those documents (or to the creator) is
+encouraged to open an issue or PR that completes this page.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,3 +26,16 @@ These pages go into great detail about everything the API can do.
    :maxdepth: 1
 
    api
+
+
+Methodology and project context
+-------------------------------
+
+For maintainers, contributors and researchers who want to understand
+*why* the tool computes what it does:
+
+.. toctree::
+   :maxdepth: 1
+
+   methodology
+   divergences

--- a/docs/methodology.rst
+++ b/docs/methodology.rst
@@ -1,0 +1,357 @@
+Methodology
+===========
+
+This page documents the theoretical foundation, terminology and analytical
+formulas behind Qualichat, drawing on the project's own published
+materials (paper, doctoral thesis, official video, public webinar).
+
+Maintainers should treat this as the source of truth for what the tool
+*intends* to compute. For the gap between intent and the current
+implementation, see :doc:`divergences`.
+
+
+Origin and lineage
+------------------
+
+Qualichat is a research instrument built to support the ethnographic
+study of mediatised groups, with a focus on Brazilian WhatsApp
+communities and their political-cultural framings. The relevant lineage:
+
+- **2019** — Fernando Luiz Nobre Cavalcante (also published as
+  *Kochav Koren Nobre*) defends his doctoral thesis at UFRN:
+  *"Vínculos de Ancoragens e Enquadramentos Temáticos: Olhares
+  Itinerantes às Interações Midiatizadas em Grupo"*.
+- **2020** — Cavalcante & Hanke publish the foundational paper
+  *"Ancoragens de interação em grupos midiatizados: proposta
+  quantiqualitativa"* in *Comunicação Mídia e Consumo* v.17 n.50,
+  `DOI 10.18568/cmc.v17i49.2227 <https://doi.org/10.18568/cmc.v17i49.2227>`_.
+- **2020-2022** — Cavalcante does his postdoc at UNICAMP IEL under
+  Prof. Marcelo Buzato, in collaboration with the University of Bremen.
+  The American Political Science Association (APSA) provides funding
+  through the *Fund for Latino Scholarship* (2020).
+- **2021** — Public release of the tool as a Python package, alongside
+  two videos on the *Os Dedos* / *Ernest Manheim* channels and an
+  installation guide on Medium.
+- **2022** — Cavalcante presents the project on the *Escola de Dados*
+  webinar `"Qualichat: conhecendo o projeto"
+  <https://www.youtube.com/watch?v=drCPx4roX-U>`_ (28/06/2022).
+
+The tool's namesake — *Ernest Manheim* — is a homage to the
+Hungarian-American sociologist (1900–2002) whose habilitation thesis
+*Die Träger der öffentlichen Meinung* (1933) pioneered the theory of
+public opinion as a *social tie* rather than a poll aggregate.
+
+
+Theoretical foundation
+----------------------
+
+Qualichat operationalises a chain of concepts from the sociology of
+interaction:
+
+- **Frame analysis** (Erving Goffman, 1974) — interactions are organised
+  by interpretive *frames* that participants signal and recognise.
+- **Anchorages** (*ancoragens*) — structural elements that ground a
+  frame: temporal markers, participant signals, message-type indicators
+  (Cavalcante & Hanke, 2020).
+- **Symbolic interactionism** — meaning emerges in interaction, not in
+  isolated utterances. The participant is read as an **actor** acting
+  within a vincular network, not as an isolated user.
+- **Public opinion as a tie** — opinion is the polarisation of
+  group-level vincular ties under tension, not the sum of individual
+  sentiments. This view derives from Manheim's communication theory and
+  contrasts with the polling-institute view of public opinion.
+
+A WhatsApp group export, in this framing, is a record of *anchored
+interaction*: each line is annotated with timestamp (temporal anchor),
+participant (vincular anchor), and message-type marker (formal anchor).
+The tool extracts these anchorages and computes derived metrics that
+support — but do not replace — qualitative ethnographic reading.
+
+
+The three frames
+----------------
+
+Qualichat exposes three analytical *frames*, each grouping a set of
+charts that answer related questions:
+
+Keys
+~~~~
+
+The lexical frame. Answers *what is being said and how*.
+
+Charts:
+
+- **Keyword** — wordcloud of co-occurring words around a user-supplied
+  term, grouped by morphological class (verbs, nouns, adjectives).
+- **Messages** — wordcloud of all messages, grouped by morphological
+  class.
+- **Laminations** — counts of laminating elements (links, e-mails,
+  mentions, emojis) per actor.
+- **Links / Calls / E-mails / Textual symbols** — drill-downs of the
+  *laminations* chart on a single dimension.
+- **Ratings** — YouTube view / like / comment counts for every shared
+  YouTube link, retrieved through the
+  `qualichat-qualitube <https://github.com/qualichat/qualichat-qualitube>`_
+  add-on (developed by Vitor Mussa, UFBA).
+
+Participation Status
+~~~~~~~~~~~~~~~~~~~~
+
+The actor-behaviour frame. Answers *who participates, how much, and
+when*.
+
+Charts:
+
+- **Messages per Actors / per Weekday** — temporal distribution of
+  participation.
+- **Message Statistics** — mean and standard deviation of message
+  length per actor.
+- **Media Repertoire** — domain breakdown of shared links per actor,
+  rendered as a treemap or bar chart.
+- **Laminations per Actors** — per-actor breakdown of the laminating
+  elements (mirrors *Keys → Laminations* but pivoted on actor).
+- **Fabrications per Actors** — per-actor breakdown of fabricating
+  elements (laughs, punctuation, numbers).
+- **Bots** — heuristic bot indicator (see :ref:`bot-heuristic`).
+
+Public Opinion
+~~~~~~~~~~~~~~
+
+The framing frame. Answers *in what tone* and *on what theme*.
+
+Charts:
+
+- **Matrix Polarity** — per-actor sentiment polarity (translates each
+  message PT→EN via ``deep-translator`` then runs the spaCyTextBlob
+  pipeline). Cavalcante intentionally does **not** call this "sentiment
+  analysis" — see his caveat in the 2022 webinar regarding the
+  philosophical and methodological limits of sentiment quantification.
+- **Linkage** — thematic linkage scoring against the bundled
+  ``connector.csv`` lexicon. Each message is scored against 21
+  pre-defined thematic groups (Friends, Political, Religious,
+  Scientific, Family, Green, Health, Spiritual, etc.) and the chat's
+  dominant frame is identified.
+
+
+Defined terms
+-------------
+
+The following terms recur in code, charts and academic prose. They have
+specific meanings in this project and should not be conflated with
+their everyday senses.
+
+Lamination
+~~~~~~~~~~
+
+The *laminating* elements of a message — markers that prepare or signal
+the discursive move rather than carrying the propositional content.
+Following Goffman's *lamination* (layered keying), Cavalcante reads
+these as:
+
+- **@-mentions** (calls) — invoking another actor into the frame.
+- **Links** — anchoring an external referent.
+- **E-mails** — addressing a third party.
+- **Emojis / textual symbols** — non-verbal cues.
+
+In the 2022 webinar Cavalcante explains the laminations as "*a
+preparação para o jogo discursivo*" — the rhetorical scaffolding around
+a message rather than its content.
+
+Fabrication
+~~~~~~~~~~~
+
+The *fabricating* elements — markers that destabilise or dissimulate
+the literal frame. In Goffman's terms, fabrications are false framings;
+in WhatsApp practice they signal informality, irony, performative
+distance:
+
+- **Laughs** (``kkk``, ``hehe``, ``hahaha``, regional variants).
+- **Punctuation marks** (``?``, ``!``, repeated for emphasis).
+- **Numbers** in informal positions.
+
+Net characters (``Qty_char_net``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The textual residue after laminations are stripped — the *unornamented*
+referential content of the message.
+
+The official formula, reproduced from the *Keys* flowchart published
+with the 2021 installation guide:
+
+.. code-block:: text
+
+    Qtd._liq._car. = Qtd._car._msg.
+                     − ( Qtd._car._chamadas
+                       + Qtd._car._links
+                       + Qtd._car._emails
+                       + Qtd._car._emojis/símbolos )
+
+Implemented in :py:mod:`qualichat.models` (see ``Message.__init__``).
+The same formula expressed in code:
+
+.. code-block:: python
+
+    net_text = remove_all_incidences(
+        self.content,
+        message['Qty_char_calls'],
+        message['Qty_char_links'],
+        message['Qty_char_emails'],
+        message['Qty_char_emoji'],
+    )
+
+Pure text (``Qty_char_text``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Net characters with fabrications also stripped. The remaining text is
+what Cavalcante calls the actor's *pure speech* — the propositional
+content with both laminations *and* fabrications removed.
+
+.. code-block:: text
+
+    Qtd._car._text = Qty_char_net
+                     − ( Qty_char_laughs
+                       + Qty_char_marks
+                       + Qty_char_numbers )
+
+Day periods and sub-periods
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Each message is tagged with a coarse and a fine temporal anchor based
+on the brazilian working-day rhythm:
+
+============  =================  =====================
+Period        Hours              Sub-period
+============  =================  =====================
+Dawn          00:00–05:59        Resting
+Morning       06:00–08:59        Transport (morning)
+Morning       09:00–11:59        Work (morning)
+Evening       12:00–14:59        Lunch
+Evening       15:00–17:59        Work (evening)
+Night         18:00–20:59        Transport (evening)
+Night         21:00–23:59        Second Office Hour
+============  =================  =====================
+
+This taxonomy is brazilian-context-specific and not meant to translate
+universally.
+
+
+.. _bot-heuristic:
+
+Bot heuristic
+-------------
+
+The ``ParticipationStatusFrame.bots`` chart applies a weighted score to
+detect non-human posting behaviour, as described by Cavalcante in the
+2022 webinar:
+
+.. code-block:: text
+
+    score = ( chars_net  × 1
+            + videos     × 2
+            + stickers   × 3 ) / 6
+
+The intuition: human participation produces text (low weight), occasional
+media (medium weight), and rarely a stream of stickers (high weight).
+Posting *only* high-weight media in tight intervals — Cavalcante cites
+"*vídeo, vídeo, vídeo, vídeo*" sequences with sub-second gaps — produces
+a high score and high standard deviation, flagging coordinated
+inhuman activity.
+
+The heuristic is **explicitly preliminary**. Cavalcante notes in the
+webinar that bot detection is an aspiration of the project, not a solved
+problem.
+
+
+Thematic linkage and the ``connector.csv``
+------------------------------------------
+
+The ``Public Opinion → Linkage`` chart classifies a chat against 21
+thematic groups defined in :file:`qualichat/connector.csv`. Each row of
+the CSV is a thematic profile with five typed columns of trigger
+keywords:
+
+- **Action** (5 keywords) — verbs that the group performs.
+- **Space** (5 keywords) — places the group occupies.
+- **Time** (5 keywords) — temporal markers the group uses.
+- **Object** (5 keywords) — material referents.
+- **Person** (5 keywords) — addressees and protagonists.
+
+The 21 groups currently encoded:
+
+Friends, Political (×2 rows), Religious, Scientific, Scholar,
+Co-workers, Family, Green, Innovation, Health care, Spiritual,
+Mentoring, Wellness, plus a Brazilian-political bundle keyed on
+``lula / bolsonaro / ciro / doria / alckmin``.
+
+The vocabulary is **specific to Brazilian Portuguese politico-cultural
+context** as of the 2018-2022 election cycle. Customising the file for
+other locales or contexts is a known need (see :doc:`divergences`).
+
+
+Ethics
+------
+
+Cavalcante is explicit about the ethical commitments of using
+Qualichat in research:
+
+1. **Prior notice to all group members.** Every actor in the analysed
+   group must be informed that conversations will be analysed.
+2. **Phone-number anonymisation.** The tool replaces every contact
+   identifier with a fictitious display name drawn from
+   :file:`qualichat/books.txt` (777 Brazilian-Portuguese public-domain
+   literary characters). Even the researcher cannot tell from the
+   output whether an actor is from DDD 85 (Ceará) or DDD 11 (São Paulo).
+3. **Ethics committee registration.** For research with hidden or
+   passive observation, registration with a university ethics committee
+   is *necessary*, not optional. In Brazil, this is the
+   `Plataforma Brasil <https://plataformabrasil.saude.gov.br/>`_ /
+   CONEP system; equivalents apply elsewhere.
+4. **No data collection by the tool itself.** Qualichat does not
+   collect, transmit or store conversation data. All processing is
+   local. The single configuration artefact at
+   ``~/.qualichat/config.json`` (Google API key + name mapping) is the
+   researcher's responsibility to handle.
+
+These commitments align with the LGPD (Brazil) and the GDPR (EU).
+
+
+References
+----------
+
+**Foundational paper**
+
+.. parsed-literal::
+
+   Cavalcante, F. L. N., & Hanke, M. M. (2020). *Ancoragens de
+   interação em grupos midiatizados: proposta quantiqualitativa*.
+   Comunicação Mídia e Consumo, 17(50), 536–558.
+   https://doi.org/10.18568/cmc.v17i49.2227
+
+**Doctoral thesis**
+
+.. parsed-literal::
+
+   Cavalcante, F. L. N. (2019). *Vínculos de Ancoragens e Enquadramentos
+   Temáticos: Olhares Itinerantes às Interações Midiatizadas em Grupo*.
+   PhD dissertation, UFRN.
+
+**Methodology flowchart (2021)**
+
+.. parsed-literal::
+
+   Cavalcante, F. L. N. (2021). *Qualichat Menu-Keys Framing Flowchart*.
+   https://www.academia.edu/87023706/
+
+**Public-facing materials**
+
+- `Como instalar o Qualichat (Medium, 2021) <https://medium.com/qualichat/como-instalar-o-qualichat-375bc1e35258>`_
+- `Os Dedos – Download Qualichat (YouTube, 18/07/2021) <https://www.youtube.com/watch?v=OMHGg3OoaKw>`_
+- `Qualichat – Combatendo Fakenews em Grupos de WhatsApp (YouTube, 24/07/2021) <https://www.youtube.com/watch?v=zFARp05xNjY>`_
+- `Qualichat: conhecendo o projeto – Webinar Escola de Dados (YouTube, 28/06/2022) <https://www.youtube.com/watch?v=drCPx4roX-U>`_
+
+**Foundational sociology**
+
+- Goffman, E. (1974). *Frame Analysis: An Essay on the Organization of
+  Experience.* Harvard University Press.
+- Manheim, E. (1933). *Die Träger der öffentlichen Meinung.*
+  Habilitationsschrift, Universität Leipzig.


### PR DESCRIPTION
## Why

This PR formalises what we learned during a maintenance audit of the project: where it came from, what it was designed to compute, who built it, and where the current implementation has drifted from the 2021 specification.

It is a **docs-only** PR. **No code change. No behaviour change.** It does not depend on #9 / #10 / #11 / #12 / #13 / #14 and it can land on \`main\` independently.

## What this PR adds

### \`docs/methodology.rst\`

The theoretical foundation of the project, drawn from primary sources:

- **Origin and lineage**: Cavalcante's UFRN thesis (2019) → Cavalcante & Hanke paper (2020) → UNICAMP postdoc with Buzato (2020-2022) → APSA Fund for Latino Scholarship → University of Bremen partnership.
- **Theoretical basis**: Goffman frames, anchorages, symbolic interactionism, public opinion as a vincular tie (Manheim).
- **The three frames** (Keys / Participation Status / Public Opinion) with the academic question each answers.
- **Defined terms**: Lamination, Fabrication, net characters, pure text — including the **official formula** \`Qtd._liq._car. = Qtd._car._msg. − (calls + links + emails + emojis)\` and a side-by-side comparison with the implementation in \`qualichat/models.py\`.
- **The bot heuristic** as Cavalcante explains it in the 2022 Escola de Dados webinar.
- **Connector.csv** — the 21 thematic groups and their five-column trigger keyword structure.
- **Ethics** — group-member notice, anonymisation, ethics-committee registration, LGPD/GDPR.
- **References** — paper, thesis, three YouTube videos, the Medium install guide, plus Goffman 1974 and Manheim 1933.

### \`docs/divergences.rst\`

Frank audit of where the current code departs from the 2021 Keys-frame flowchart (the only published specification):

| # | Severity | Item |
|---|---|---|
| D1 | 🔴 critical (semantic) | \`laminations\` plots components instead of the residue \`Qtd._liq._car.\` specified by the formula |
| D2 | 🔴 critical (analytical) | \`messages\` skips the three character-count panels the spec demands |
| D3 | 🔴 critical (analytical) | \`keyword\` produces a single wordcloud instead of three simultaneous (verbs / nouns / adjectives) |
| D4 | 🟡 medium | Missing "By Group" sorter mode |
| D5 | 🟡 cosmetic | "Gráfico de Relevância" label not used in UI |
| D6 | 🟢 addition | \`ratings\` exists in code but not in the 2021 flowchart — added in 2022 with \`qualichat-qualitube\` (Vitor Mussa, UFBA), deliberate extension not regression |

For each item: source-of-truth reference (file:line), severity rationale, and the maintainers' standing decision (**preserve current behaviour**, treat as documented gap rather than bug). The page also lists items still to be audited (the flowcharts for Participation Status and Public Opinion have not been located).

### \`AUTHORS.md\`

Academic team (Cavalcante / Buzato / Hanke), software contributors (kyomi / cazemoises / Caio Alexandre / Vitor Mussa / João Paulo), design (Pedro Oliver), funding (APSA / UNICAMP / Bremen / Ernest Manheim Lab). Includes a section on the namesake — the sociologist **Ernest Manheim** (1900-2002), whose 1933 habilitation thesis pioneered the theory of public opinion as a *social tie* and from whom the project's lab and \`__author__\` field take their name.

### \`CITATION.cff\`

Software citation plus the foundational paper as \`preferred-citation\`, so anyone using Qualichat in academic work has the canonical reference at hand:

> Nobre Cavalcante, F. L., & Hanke, M. M. (2020). *Ancoragens de interação em grupos midiatizados: proposta quantiqualitativa*. Comunicação Mídia e Consumo, 17(50), 536-558. https://doi.org/10.18568/cmc.v17i49.2227

### \`docs/index.rst\`

Toctree updated to include the two new pages under a *"Methodology and project context"* section.

## Sources used

| Source | What it gave |
|---|---|
| [Cavalcante & Hanke (2020)](https://revistacmc.espm.br/revistacmc/article/view/2227) — paper-mãe | Anchorage theory, frame analysis adaptation, quanti-qualitative method |
| [Cavalcante (2021) — Menu-Keys Framing Flowchart (Academia.edu)](https://www.academia.edu/87023706/) | The Keys-frame menu structure and the \`Qtd._liq._car.\` formula |
| [\"Como instalar o Qualichat\" (Medium, 2021)](https://medium.com/qualichat/como-instalar-o-qualichat-375bc1e35258) | Installation flow and ethics section |
| [Webinar \"Qualichat: conhecendo o projeto\" (Escola de Dados, 28/06/2022, ~30 min)](https://www.youtube.com/watch?v=drCPx4roX-U) | Origin story, Lamination/Fabrication definitions, bot heuristic, future work |
| [\"Os Dedos – Download Qualichat\" (YouTube, 18/07/2021)](https://www.youtube.com/watch?v=OMHGg3OoaKw) | Project mission and statement of purpose |
| [UNICAMP news (26/07/2021)](https://www2.unicamp.br/unicamp/noticias/2021/07/26/ferramenta-desenvolvida-na-unicamp-auxilia-em-pesquisas-sobre-fake-news-no) and [FAPESP](https://agencia.fapesp.br/laboratorio-recebe-inscricoes-de-interessados-em-testar-ferramenta-de-combate-a-ifake-news-i/39110/) | Institutional context |

## Decision: keep current behaviour

The maintainers' standing decision for every divergence in \`docs/divergences.rst\` is **preserve current behaviour**. Existing users of v1.4.x have been working against the current chart outputs since approximately 2022, and any of these "fixes" would be a behaviour change rather than a bug fix. Each divergence is now documented and can be revisited deliberately by a future maintainer (or by the project's creator) when the time is right.

## Test plan

- [ ] \`sphinx-build -W docs docs/_build\` builds without warnings on the two new pages
- [ ] RTD renders the new sidebar section after merge
- [ ] No CI workflow exists in \`main\` yet (the test workflow is introduced by #9), so this PR has no CI; it is a docs-only change reviewable by inspection.